### PR TITLE
Fix a couple of small issues.

### DIFF
--- a/bsnes/snes/chip/dos/fdd_dos.h
+++ b/bsnes/snes/chip/dos/fdd_dos.h
@@ -220,7 +220,7 @@ static bool fdd_dos_insert_empty(fdd_t* fdd, int data_size) {
                 fdd_sector_t* sector = &track->sectors[sector_index];
                 sector->info.upd765.c = track_index;
                 sector->info.upd765.h = side_index;
-                sector->info.upd765.r = sector_index;
+                sector->info.upd765.r = sector_index+1;
                 sector->info.upd765.n = 0xFF;
                 sector->info.upd765.st1 = 0;
                 sector->info.upd765.st2 = 0;

--- a/snesreader/7z_C/CpuArch.c
+++ b/snesreader/7z_C/CpuArch.c
@@ -75,7 +75,7 @@ static void MyCPUID(UInt32 function, UInt32 *a, UInt32 *b, UInt32 *c, UInt32 *d)
   // Mac cross-compile compiler:
   //  can't find register in class 'BREG' while reloading 'asm'
   // so use class 'r' register var binding
-  register _b asm("%bx");
+  register int _b asm("%bx");
   __asm__ __volatile__ (
     "cpuid"
     : "=a" (*a) ,


### PR DESCRIPTION
(a) My compiler doesn't like `register` without a type on it.

(b) disks created by the FDD code are formatted with sector IDs from 0..17, rather than from 1..18, causing very weird things when I try to write sector 18. (Although I'm not really sure how this can work at all, given that the fdd_dos code is only creating nine sectors per track. It does appear to be, though...)